### PR TITLE
Fix credProtect extension handling

### DIFF
--- a/examples/server/server/server.py
+++ b/examples/server/server/server.py
@@ -128,11 +128,11 @@ def _make_json_safe(value: Any) -> Any:
 
 CRED_PROTECT_LABELS: Dict[Any, str] = {
     1: "userVerificationOptional",
-    2: "userVerificationOptionalWithCredentialIdList",
+    2: "userVerificationOptionalWithCredentialIDList",
     3: "userVerificationRequired",
     "userVerificationOptional": "userVerificationOptional",
-    "userVerificationOptionalWithCredentialIDList": "userVerificationOptionalWithCredentialIdList",
-    "userVerificationOptionalWithCredentialIdList": "userVerificationOptionalWithCredentialIdList",
+    "userVerificationOptionalWithCredentialIDList": "userVerificationOptionalWithCredentialIDList",
+    "userVerificationOptionalWithCredentialIdList": "userVerificationOptionalWithCredentialIDList",
     "userVerificationRequired": "userVerificationRequired",
 }
 
@@ -1089,18 +1089,25 @@ def advanced_register_begin():
         elif ext_name == "minPinLength":
             processed_extensions["minPinLength"] = bool(ext_value)
         elif ext_name in ("credProtect", "credentialProtectionPolicy"):
-            if isinstance(ext_value, str):
+            if isinstance(ext_value, int):
                 protect_map = {
-                    "userVerificationOptional": 1,
-                    "userVerificationOptionalWithCredentialIDList": 2,
-                    "userVerificationOptionalWithCredentialIdList": 2,
-                    "userVerificationRequired": 3
+                    1: "userVerificationOptional",
+                    2: "userVerificationOptionalWithCredentialIDList",
+                    3: "userVerificationRequired",
                 }
-                processed_extensions["credProtect"] = protect_map.get(ext_value, ext_value)
+                processed_extensions["credentialProtectionPolicy"] = protect_map.get(ext_value, ext_value)
+            elif isinstance(ext_value, str):
+                alias_map = {
+                    "userVerificationOptional": "userVerificationOptional",
+                    "userVerificationOptionalWithCredentialIDList": "userVerificationOptionalWithCredentialIDList",
+                    "userVerificationOptionalWithCredentialIdList": "userVerificationOptionalWithCredentialIDList",
+                    "userVerificationRequired": "userVerificationRequired",
+                }
+                processed_extensions["credentialProtectionPolicy"] = alias_map.get(ext_value, ext_value)
             else:
-                processed_extensions["credProtect"] = ext_value
+                processed_extensions["credentialProtectionPolicy"] = ext_value
         elif ext_name in ("enforceCredProtect", "enforceCredentialProtectionPolicy"):
-            processed_extensions["enforceCredProtect"] = bool(ext_value)
+            processed_extensions["enforceCredentialProtectionPolicy"] = bool(ext_value)
         elif ext_name == "largeBlob":
             if isinstance(ext_value, str):
                 processed_extensions["largeBlob"] = {"support": ext_value}
@@ -1349,7 +1356,7 @@ def advanced_register_complete():
 
         cred_protect_mapping = {
             1: "userVerificationOptional",
-            2: "userVerificationOptionalWithCredentialIdList",
+            2: "userVerificationOptionalWithCredentialIDList",
             3: "userVerificationRequired",
         }
 

--- a/examples/server/server/static/script.js
+++ b/examples/server/server/static/script.js
@@ -514,18 +514,28 @@ window.parseRequestOptionsFromJSON = parseRequestOptionsFromJSON;
         }
 
         function convertCredProtectValue(value) {
-            if (typeof value === 'number') {
-                return value;
-            }
-
-            const mapping = {
-                userVerificationOptional: 1,
-                userVerificationOptionalWithCredentialIDList: 2,
-                userVerificationOptionalWithCredentialIdList: 2,
-                userVerificationRequired: 3
+            const numberToPolicy = {
+                1: 'userVerificationOptional',
+                2: 'userVerificationOptionalWithCredentialIDList',
+                3: 'userVerificationRequired'
             };
 
-            return mapping[value] ?? value;
+            const stringNormalization = {
+                userVerificationOptional: 'userVerificationOptional',
+                userVerificationOptionalWithCredentialIDList: 'userVerificationOptionalWithCredentialIDList',
+                userVerificationOptionalWithCredentialIdList: 'userVerificationOptionalWithCredentialIDList',
+                userVerificationRequired: 'userVerificationRequired'
+            };
+
+            if (typeof value === 'number') {
+                return numberToPolicy[value] ?? value;
+            }
+
+            if (typeof value === 'string') {
+                return stringNormalization[value] ?? value;
+            }
+
+            return value;
         }
 
         function convertLargeBlobExtension(extValue) {
@@ -637,16 +647,12 @@ window.parseRequestOptionsFromJSON = parseRequestOptionsFromJSON;
             Object.entries(extensionsJson).forEach(([name, value]) => {
                 switch (name) {
                     case 'credProtect':
-                        converted.credProtect = convertCredProtectValue(value);
-                        break;
                     case 'credentialProtectionPolicy':
-                        converted.credProtect = convertCredProtectValue(value);
+                        converted.credentialProtectionPolicy = convertCredProtectValue(value);
                         break;
                     case 'enforceCredProtect':
-                        converted.enforceCredProtect = !!value;
-                        break;
                     case 'enforceCredentialProtectionPolicy':
-                        converted.enforceCredProtect = !!value;
+                        converted.enforceCredentialProtectionPolicy = !!value;
                         break;
                     case 'largeBlob':
                         converted.largeBlob = convertLargeBlobExtension(value);
@@ -1341,10 +1347,10 @@ window.parseRequestOptionsFromJSON = parseRequestOptionsFromJSON;
             const credProtectSetting = serverData.credProtectUsed ?? 'none';
             const credProtectLabelMap = {
                 1: 'userVerificationOptional',
-                2: 'userVerificationOptionalWithCredentialIdList',
+                2: 'userVerificationOptionalWithCredentialIDList',
                 3: 'userVerificationRequired',
-                userVerificationOptionalWithCredentialIDList: 'userVerificationOptionalWithCredentialIdList',
-                userVerificationOptionalWithCredentialIdList: 'userVerificationOptionalWithCredentialIdList',
+                userVerificationOptionalWithCredentialIDList: 'userVerificationOptionalWithCredentialIDList',
+                userVerificationOptionalWithCredentialIdList: 'userVerificationOptionalWithCredentialIDList',
             };
             const credProtectDisplay = credProtectLabelMap[credProtectSetting] || credProtectSetting || 'none';
             console.log('credprotect setting:', credProtectDisplay);


### PR DESCRIPTION
## Summary
- normalize credProtect extension handling on the server so credentialProtectionPolicy and its enforcement flag are forwarded with canonical values
- update the frontend conversion helpers to keep credentialProtectionPolicy strings, convert numeric inputs, and align debug labels with the canonical names

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca88466738832c9139e4172279974a