### PR TITLE
Sanitize MDS certificates and cache metadata

### DIFF
--- a/examples/server/server/static/mds.html
+++ b/examples/server/server/static/mds.html
@@ -260,9 +260,6 @@
     <div class="mds-modal__dialog mds-modal__dialog--authenticator" role="dialog" aria-modal="true" aria-labelledby="mds-authenticator-modal-title">
         <div class="mds-modal__header mds-modal__header--authenticator">
             <div class="mds-modal__header-main">
-                <button type="button" id="mds-authenticator-modal-back" class="mds-detail-back mds-modal__back">
-                    ← Back to authenticator list
-                </button>
                 <div class="mds-modal__heading">
                     <h3 id="mds-authenticator-modal-title" class="mds-modal__title">Authenticator</h3>
                     <p id="mds-authenticator-modal-subtitle" class="mds-modal__subtitle"></p>

--- a/examples/server/server/static/mds/detail.css
+++ b/examples/server/server/static/mds/detail.css
@@ -19,23 +19,7 @@
 }
 
 .mds-detail-back {
-    appearance: none;
-    border: none;
-    background: rgba(0, 114, 206, 0.12);
-    color: var(--primary-dark);
-    font-weight: 600;
-    padding: 0.45rem 0.9rem;
-    border-radius: 999px;
-    cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.mds-detail-back:hover,
-.mds-detail-back:focus-visible {
-    background: rgba(0, 114, 206, 0.18);
-    color: var(--primary-color);
-    outline: none;
-    transform: translateY(-1px);
+    display: none !important;
 }
 
 .mds-detail-heading {

--- a/examples/server/server/static/mds/modal.css
+++ b/examples/server/server/static/mds/modal.css
@@ -33,6 +33,13 @@
     flex-direction: column;
 }
 
+.mds-modal__dialog--certificate {
+    width: 88vw;
+    max-width: 900px;
+    height: 88vh;
+    max-height: 88vh;
+}
+
 .mds-modal__header {
     display: flex;
     align-items: center;
@@ -178,10 +185,6 @@
     gap: 0.85rem;
     flex: 1 1 auto;
     min-width: 0;
-}
-
-.mds-modal__back {
-    align-self: flex-start;
 }
 
 .mds-detail--modal {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.8"
 cryptography = ">=2.6, !=35, <45"
+asn1crypto = "^1.5.1"
 pyscard = {version = "^1.9 || ^2", optional = true}
 
 cbor2 = "^5.6.4"           # CBOR parsing


### PR DESCRIPTION
## Summary
- sanitize attestation certificate parsing to normalise non-compliant serial numbers, strip forbidden NULL algorithm parameters, and surface parsing warnings while computing fingerprints from the original DER bytes
- add the asn1crypto dependency required for the certificate sanitisation logic
- cache the MDS metadata payload in localStorage, reuse it on reload, refresh the fetch logic, and tidy the authenticator modal UI by removing the redundant back button and tweaking modal sizing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0efa17de8832cb23d9805b2365ac1