### PR TITLE
Adjust MDS UI loading behavior and layout

### DIFF
--- a/examples/server/server/static/mds.html
+++ b/examples/server/server/static/mds.html
@@ -260,9 +260,6 @@
     <div class="mds-modal__dialog mds-modal__dialog--authenticator" role="dialog" aria-modal="true" aria-labelledby="mds-authenticator-modal-title">
         <div class="mds-modal__header mds-modal__header--authenticator">
             <div class="mds-modal__header-main">
-                <button type="button" id="mds-authenticator-modal-back" class="mds-detail-back mds-modal__back">
-                    ← Back to authenticator list
-                </button>
                 <div class="mds-modal__heading">
                     <h3 id="mds-authenticator-modal-title" class="mds-modal__title">Authenticator</h3>
                     <p id="mds-authenticator-modal-subtitle" class="mds-modal__subtitle"></p>

--- a/examples/server/server/static/mds/detail.css
+++ b/examples/server/server/static/mds/detail.css
@@ -18,26 +18,6 @@
     flex-wrap: wrap;
 }
 
-.mds-detail-back {
-    appearance: none;
-    border: none;
-    background: rgba(0, 114, 206, 0.12);
-    color: var(--primary-dark);
-    font-weight: 600;
-    padding: 0.45rem 0.9rem;
-    border-radius: 999px;
-    cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.mds-detail-back:hover,
-.mds-detail-back:focus-visible {
-    background: rgba(0, 114, 206, 0.18);
-    color: var(--primary-color);
-    outline: none;
-    transform: translateY(-1px);
-}
-
 .mds-detail-heading {
     display: flex;
     flex-direction: column;

--- a/examples/server/server/static/mds/modal.css
+++ b/examples/server/server/static/mds/modal.css
@@ -33,6 +33,13 @@
     flex-direction: column;
 }
 
+.mds-modal__dialog--certificate {
+    width: min(80vw, 1100px);
+    max-width: 80vw;
+    height: min(80vh, 900px);
+    max-height: 80vh;
+}
+
 .mds-modal__header {
     display: flex;
     align-items: center;
@@ -178,10 +185,6 @@
     gap: 0.85rem;
     flex: 1 1 auto;
     min-width: 0;
-}
-
-.mds-modal__back {
-    align-self: flex-start;
 }
 
 .mds-detail--modal {

--- a/examples/server/server/static/mds/table.css
+++ b/examples/server/server/static/mds/table.css
@@ -38,11 +38,20 @@
     z-index: 3;
 }
 
+.mds-column-resizer.is-disabled {
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 .mds-column-resizer::before {
     content: '';
     width: 1px;
     background: rgba(0, 114, 206, 0.22);
     height: 100%;
+}
+
+.mds-column-resizer.is-disabled::before {
+    background: rgba(0, 114, 206, 0.12);
 }
 
 .mds-column-resizer:hover::before,


### PR DESCRIPTION
## Summary
- cache downloaded MDS metadata in session storage and update the loader to reuse cached content while respecting manual refreshes
- disable MDS table column resizers while metadata is loading and add CSS to reflect the disabled state
- streamline the authenticator modal by removing the extra back button and reduce the certificate modal size to about 80% of the viewport

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0fa8555fc832c9eed289a0f1f502b