### PR TITLE
Fix simple auth username persistence and messaging

### DIFF
--- a/examples/server/server/static/auth-simple.js
+++ b/examples/server/server/static/auth-simple.js
@@ -103,7 +103,7 @@ export async function simpleRegister() {
 export async function simpleAuthenticate() {
     const email = document.getElementById('simple-email').value;
     if (!email) {
-        showStatus('simple', 'Please enter a username. ', 'error');
+        showStatus('simple', 'Please enter a username.', 'error');
         return;
     }
 
@@ -118,7 +118,7 @@ export async function simpleAuthenticate() {
 
         if (!response.ok) {
             if (response.status === 404) {
-                throw new Error('No credentials found for this email. Please register first.');
+                throw new Error('No credentials found for this username. Please register first.');
             }
             const errorText = await response.text();
             throw new Error(`Server error: ${errorText}`);

--- a/examples/server/server/static/username.js
+++ b/examples/server/server/static/username.js
@@ -28,9 +28,16 @@ export function randomizeUserIdentity() {
     randomizeUsername();
 }
 
+let hasRandomizedSimpleUsername = false;
+
 export function randomizeSimpleUsername() {
+    if (hasRandomizedSimpleUsername) {
+        return;
+    }
+
     const simpleInput = document.getElementById('simple-email');
     if (simpleInput) {
         simpleInput.value = generateRandom10DigitUsername();
+        hasRandomizedSimpleUsername = true;
     }
 }


### PR DESCRIPTION
## Summary
- prevent the simple authentication username input from re-randomizing after the initial page load
- update the simple authentication 404 error message to refer to a username instead of an email

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68d512ed8388832cb8c31c7e2f34ddde