### PR TITLE
Handle raw ECDSA attestation signatures

### DIFF
--- a/tests/test_cose_ecdsa_signatures.py
+++ b/tests/test_cose_ecdsa_signatures.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Type
 
+import pytest
+
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 from cryptography.hazmat.primitives import hashes
@@ -42,3 +44,42 @@ def test_es512_accepts_raw_signatures() -> None:
 
 def test_es256k_accepts_raw_signatures() -> None:
     _exercise_raw_signature(ES256K, ec.SECP256K1(), hashes.SHA256)
+
+
+def _exercise_truncated_raw_signature(
+    cose_cls: Type[CoseKey],
+    curve: ec.EllipticCurve,
+    hash_algorithm_cls: Type[hashes.HashAlgorithm],
+) -> None:
+    private_key = ec.generate_private_key(curve)
+    message = b"ecdsa-message-truncated"
+    coordinate_length = (curve.key_size + 7) // 8
+    for _ in range(4096):
+        signature = private_key.sign(message, ec.ECDSA(hash_algorithm_cls()))
+        r, s = decode_dss_signature(signature)
+        r_bytes = r.to_bytes(coordinate_length, "big")
+        s_bytes = s.to_bytes(coordinate_length, "big")
+        truncated_r = r_bytes.lstrip(b"\x00") or b"\x00"
+        truncated_s = s_bytes.lstrip(b"\x00") or b"\x00"
+        if len(truncated_r) < coordinate_length or len(truncated_s) < coordinate_length:
+            truncated_signature = truncated_r + truncated_s
+            cose_key = cose_cls.from_cryptography_key(private_key.public_key())
+            cose_key.verify(message, truncated_signature)
+            return
+    pytest.skip("failed to generate truncated raw ECDSA signature")
+
+
+def test_es256_accepts_truncated_raw_signatures() -> None:
+    _exercise_truncated_raw_signature(ES256, ec.SECP256R1(), hashes.SHA256)
+
+
+def test_es384_accepts_truncated_raw_signatures() -> None:
+    _exercise_truncated_raw_signature(ES384, ec.SECP384R1(), hashes.SHA384)
+
+
+def test_es512_accepts_truncated_raw_signatures() -> None:
+    _exercise_truncated_raw_signature(ES512, ec.SECP521R1(), hashes.SHA512)
+
+
+def test_es256k_accepts_truncated_raw_signatures() -> None:
+    _exercise_truncated_raw_signature(ES256K, ec.SECP256K1(), hashes.SHA256)


### PR DESCRIPTION
## Summary
- detect and convert raw ECDSA signatures to DER form before verification
- cover ES256/ES384/ES512/ES256K with tests to ensure raw attestation signatures are accepted

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d6622e265c832c9661c5f0d349b75f