### PR TITLE
Ensure ML-DSA attestation chains use PQ certificate verification

### DIFF
--- a/fido2/attestation/base.py
+++ b/fido2/attestation/base.py
@@ -167,15 +167,18 @@ def verify_x509_chain(chain: List[bytes]) -> None:
     while certs:
         child = cert
         cert, cert_der = certs.pop(0)
-        print("Signature Algorithm OID:", child.signature_algorithm_oid.dotted_string)
-        print("Signature Algorithm Name:", getattr(child.signature_algorithm_oid, "_name", "unknown"))
+
+        signature_algorithm_oid = child.signature_algorithm_oid.dotted_string
+        if describe_mldsa_oid(signature_algorithm_oid):
+            _verify_mldsa_certificate_signature(child, cert_der)
+            continue
+
         try:
             pub = cert.public_key()
         except ValueError:
             pub = None
         try:
             if isinstance(pub, rsa.RSAPublicKey):
-                print("RSA is used")
                 assert child.signature_hash_algorithm is not None  # nosec
                 pub.verify(
                     child.signature,
@@ -184,7 +187,6 @@ def verify_x509_chain(chain: List[bytes]) -> None:
                     child.signature_hash_algorithm,
                 )
             elif isinstance(pub, ec.EllipticCurvePublicKey):
-                print("ec is used")
                 assert child.signature_hash_algorithm is not None  # nosec
                 pub.verify(
                     child.signature,
@@ -192,7 +194,6 @@ def verify_x509_chain(chain: List[bytes]) -> None:
                     ec.ECDSA(child.signature_hash_algorithm),
                 )
             elif pub is None:
-                print("ML-DSA is used")
                 _verify_mldsa_certificate_signature(child, cert_der)
             else:
                 raise ValueError("Unsupported signature key type")

--- a/tests/test_pqc_chain.py
+++ b/tests/test_pqc_chain.py
@@ -12,6 +12,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from fido2.attestation.base import verify_x509_chain
 from fido2.cose import extract_certificate_public_key_info
@@ -72,3 +73,48 @@ def test_verify_x509_chain_uses_ml_dsa(monkeypatch):
     assert signature_recorder["message"] == root_cert.tbs_certificate_bytes
     assert signature_recorder["signature"] == root_cert.signature
     assert signature_recorder["public_key"] == public_key_info["subject_public_key"]
+
+
+def test_verify_x509_chain_prefers_mldsa_by_oid(monkeypatch):
+    metadata_path = "examples/server/server/static/feitian-pqc.json"
+    with open(metadata_path, "r", encoding="utf-8") as fh:
+        metadata = json.load(fh)
+
+    root_der = base64.b64decode(metadata["attestationRootCertificates"][0])
+    original_loader = x509.load_der_x509_certificate
+    original_cert = original_loader(root_der, default_backend())
+
+    class FakeCertificate:
+        def __init__(self, cert, fake_public_key):
+            self._cert = cert
+            self._fake_public_key = fake_public_key
+
+        def __getattr__(self, item):
+            return getattr(self._cert, item)
+
+        def public_key(self):
+            return self._fake_public_key
+
+    fake_rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048).public_key()
+
+    def fake_loader(der, backend):
+        cert = original_loader(der, backend)
+        return FakeCertificate(cert, fake_rsa_key)
+
+    monkeypatch.setattr(x509, "load_der_x509_certificate", fake_loader)
+
+    captured = {}
+
+    def fake_verify(child_cert, issuer_der):
+        captured["child"] = child_cert
+        captured["issuer_der"] = issuer_der
+
+    monkeypatch.setattr(
+        "fido2.attestation.base._verify_mldsa_certificate_signature",
+        fake_verify,
+    )
+
+    verify_x509_chain([root_der, root_der])
+
+    assert captured["child"].signature == original_cert.signature
+    assert captured["issuer_der"] == root_der


### PR DESCRIPTION
## Summary
- ensure `verify_x509_chain` routes ML-DSA signatures to the post-quantum verification helper based on the certificate signature OID
- keep RSA/ECDSA verification paths unchanged while allowing PQ verification to succeed when cryptography returns a parseable key
- add regression coverage that forces an ML-DSA certificate to surface as RSA to confirm the PQ verification path is still used

## Testing
- pytest tests/test_pqc_chain.py

------
https://chatgpt.com/codex/tasks/task_e_68db7276718c832ca80016af17669bf0