### PR TITLE
chore(deps): update google-auth requirement from >=2.56.0 to >=2.56.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ cbor2>=5.6.4
 certifi>=2026.7.22  # optional: improves TLS validation for metadata downloads
 gunicorn>=26.0.0,<27.0
 google-api-core>=2.33.0
-google-auth>=2.56.0
+google-auth>=2.56.2
 google-cloud-core>=2.6.0
 google-cloud-storage>=3.13.0


### PR DESCRIPTION
Replaces #191 which had merge conflicts after #190 and #192 were merged.

Updates the minimum version constraint for google-auth from >=2.56.0 to >=2.56.2.

This is a dependency version floor bump only — no code changes.